### PR TITLE
Increase open file limit in build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "copy-libs": "mkdir -p static/build/lib && npm run copy-jquery && npm run copy-holder && npm run copy-bootstrap",
     "build-js": "mkdir -p static/build/js && browserify -t babelify static/js/index.js -o static/build/js/index.js",
     "watch-js": "watchify -t babelify static/js/index.js -o static/build/js/index.js -v",
-    "build": "npm install && npm run copy-libs && npm run build-js",
+    "build": "ulimit -n 512 && npm install && npm run copy-libs && npm run build-js",
     "watch": "npm run build && npm run watch-js",
     "lint": "jshint 'static/js/' && jscs 'static/js/'",
     "test": "npm run lint"


### PR DESCRIPTION
Prevents EMFILE error when building javascript.
