### PR TITLE
Prevent overlapping variable names

### DIFF
--- a/static/js/components/form-collection.js
+++ b/static/js/components/form-collection.js
@@ -77,7 +77,9 @@ var FormCollection = React.createClass({
         <div className='form-group' key={child.name}>
           {label}
           <label>
-            {child.name}
+            <span className='variable-name' title={child.name}>
+              {child.name}
+            </span>
             <span
               className='glyphicon glyphicon glyphicon-search'
               onClick={this.addToSearch.bind(null, child.name)} />

--- a/static/less/index.less
+++ b/static/less/index.less
@@ -204,6 +204,29 @@ a {
   height: 100%;
   overflow: auto;
   text-align: left;
+
+  label {
+    position: relative;
+
+    .variable-name {
+      display: block;
+      position: relative;
+      width: 100%;
+      padding-right: 20px;
+      z-index: 0;
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+    }
+
+    .glyphicon {
+      position: absolute;
+      top: 0;
+      right: 0;
+      z-index: 1;
+      cursor: pointer;
+    }
+  }
 }
 
 /* @end Sidebar */


### PR DESCRIPTION
Fixes #67 
- Adjust variable name & search icon styles
- Add title to variable names (as they are now ellipsized)

![screen shot 2015-07-15 at 17 51 36](https://cloud.githubusercontent.com/assets/5850625/8704349/4f04f882-2b1a-11e5-9d85-570b0d114367.png)
